### PR TITLE
Fix apppack.toml artifact archival for custom APPPACK_TOML paths

### DIFF
--- a/builder/build/apppacktoml.go
+++ b/builder/build/apppacktoml.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/apppackio/codebuild-image/builder/filesystem"
 	"github.com/BurntSushi/toml"
+	"github.com/apppackio/codebuild-image/builder/filesystem"
 	"github.com/rs/zerolog/log"
 )
 

--- a/builder/build/build.go
+++ b/builder/build/build.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/apppackio/codebuild-image/builder/containers"
+	"github.com/apppackio/codebuild-image/builder/filesystem"
 	"github.com/docker/docker/api/types/container"
 	"github.com/google/go-containerregistry/pkg/crane"
 	cp "github.com/otiai10/copy"
@@ -120,6 +121,11 @@ func (b *Build) RunBuild() error {
 	}
 	if err = cp.Copy(logFile.Name(), "build.log"); err != nil {
 		return err
+	}
+	// Copy the apppack.toml file to the default location if it was read from a custom location
+	if err = filesystem.CopyAppPackTomlToDefault(); err != nil {
+		b.Log().Warn().Err(err).Msg("Failed to copy apppack.toml to default location for artifact archival")
+		// Don't fail the build if we can't copy the file, just warn
 	}
 	return b.state.WriteCommitTxt()
 }


### PR DESCRIPTION
## Summary
- Ensures apppack.toml is included in build artifacts when using custom APPPACK_TOML environment variable
- Adds automatic copying of custom config file to default location after build completion
- Prevents missing configuration in archived build artifacts

## Context
This is a follow-up to PR #11 which added support for reading apppack.toml from a custom location via the APPPACK_TOML environment variable. However, the build artifacts were missing the configuration file when it was read from a non-default location.

## Changes
- Added `CopyAppPackTomlToDefault()` function to copy custom config to default location
- Integrated the copy operation into the build process with non-fatal error handling
- Added comprehensive test coverage for the new functionality
- Refactored to use `DefaultAppPackTomlFilename` constant for consistency

## Test plan
- [x] Added unit tests for `CopyAppPackTomlToDefault()` covering all scenarios
- [ ] Test with default apppack.toml location (no-op case)
- [ ] Test with custom APPPACK_TOML path to verify copy works
- [ ] Test with missing custom file to verify graceful error handling
- [ ] Verify build artifacts include apppack.toml after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)