### PR TITLE
Pass standard CI vars as build args (fixes #13)

### DIFF
--- a/builder/build/build.go
+++ b/builder/build/build.go
@@ -38,6 +38,11 @@ func (b *Build) LoadBuildEnv() (map[string]string, error) {
 	if val, ok := os.LookupEnv("ALLOW_EOL_SHIMMED_BUILDER"); ok {
 		env["ALLOW_EOL_SHIMMED_BUILDER"] = val
 	}
+	// map CodeBuild-specific vars to neutral CI vars and pass as build args
+	env["CI_COMMIT_REF"] = GetenvFallback([]string{"CODEBUILD_WEBHOOK_HEAD_REF", "CODEBUILD_SOURCE_VERSION"})
+	env["CI_COMMIT_SHA"] = os.Getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
+	env["CI_BUILD_STARTED_AT"] = os.Getenv("CODEBUILD_START_TIME")
+	env["CI_REPOSITORY_URL"] = os.Getenv("CODEBUILD_SOURCE_REPO_URL")
 	params, err := b.aws.GetParametersByPath(paths[0])
 	stripParamPrefix(params, paths[0], &env)
 	if err != nil {

--- a/builder/build/build.go
+++ b/builder/build/build.go
@@ -38,11 +38,18 @@ func (b *Build) LoadBuildEnv() (map[string]string, error) {
 	if val, ok := os.LookupEnv("ALLOW_EOL_SHIMMED_BUILDER"); ok {
 		env["ALLOW_EOL_SHIMMED_BUILDER"] = val
 	}
-	// map CodeBuild-specific vars to neutral CI vars and pass as build args
-	env["CI_COMMIT_REF"] = GetenvFallback([]string{"CODEBUILD_WEBHOOK_HEAD_REF", "CODEBUILD_SOURCE_VERSION"})
-	env["CI_COMMIT_SHA"] = os.Getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
-	env["CI_BUILD_STARTED_AT"] = os.Getenv("CODEBUILD_START_TIME")
-	env["CI_REPOSITORY_URL"] = os.Getenv("CODEBUILD_SOURCE_REPO_URL")
+	// map CodeBuild-specific vars to neutral CI vars and pass into Docker builds as build args
+	// and into buildpack builds as env vars
+	for k, v := range map[string]string{
+		"CI_COMMIT_REF":       GetenvFallback([]string{"CODEBUILD_WEBHOOK_HEAD_REF", "CODEBUILD_SOURCE_VERSION"}),
+		"CI_COMMIT_SHA":       os.Getenv("CODEBUILD_RESOLVED_SOURCE_VERSION"),
+		"CI_BUILD_STARTED_AT": os.Getenv("CODEBUILD_START_TIME"),
+		"CI_REPOSITORY_URL":   os.Getenv("CODEBUILD_SOURCE_REPO_URL"),
+	} {
+		if v != "" {
+			env[k] = v
+		}
+	}
 	params, err := b.aws.GetParametersByPath(paths[0])
 	stripParamPrefix(params, paths[0], &env)
 	if err != nil {

--- a/builder/build/build_test.go
+++ b/builder/build/build_test.go
@@ -80,6 +80,71 @@ func TestLoadEnvInheritance(t *testing.T) {
 	}
 }
 
+func TestLoadBuildEnvCIVars(t *testing.T) {
+	appName := "test-app"
+	mockedAWS := new(MockAWS)
+	appConfigPrefix := fmt.Sprintf("/apppack/apps/%s/config/", appName)
+	mockedAWS.On("GetParametersByPath", appConfigPrefix).Return(map[string]string{}, nil)
+	mockedState := emptyState()
+	mockedState.On("ReadEnvFile").Return(&map[string]string{}, nil)
+
+	t.Setenv("CODEBUILD_WEBHOOK_HEAD_REF", "refs/heads/main")
+	t.Setenv("CODEBUILD_RESOLVED_SOURCE_VERSION", "deadbeef1234")
+	t.Setenv("CODEBUILD_START_TIME", "1234567890")
+	t.Setenv("CODEBUILD_SOURCE_REPO_URL", "https://github.com/org/repo")
+
+	b := Build{
+		Appname:          appName,
+		CodebuildBuildId: CodebuildBuildId,
+		aws:              mockedAWS,
+		state:            mockedState,
+		Ctx:              testContext,
+	}
+	env, err := b.LoadBuildEnv()
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+	if env["CI_COMMIT_REF"] != "refs/heads/main" {
+		t.Errorf("expected CI_COMMIT_REF=refs/heads/main, got %s", env["CI_COMMIT_REF"])
+	}
+	if env["CI_COMMIT_SHA"] != "deadbeef1234" {
+		t.Errorf("expected CI_COMMIT_SHA=deadbeef1234, got %s", env["CI_COMMIT_SHA"])
+	}
+	if env["CI_BUILD_STARTED_AT"] != "1234567890" {
+		t.Errorf("expected CI_BUILD_STARTED_AT=1234567890, got %s", env["CI_BUILD_STARTED_AT"])
+	}
+	if env["CI_REPOSITORY_URL"] != "https://github.com/org/repo" {
+		t.Errorf("expected CI_REPOSITORY_URL=https://github.com/org/repo, got %s", env["CI_REPOSITORY_URL"])
+	}
+}
+
+func TestLoadBuildEnvCIVarsFallback(t *testing.T) {
+	// When CODEBUILD_WEBHOOK_HEAD_REF is not set, CI_COMMIT_REF should fall back to CODEBUILD_SOURCE_VERSION
+	appName := "test-app"
+	mockedAWS := new(MockAWS)
+	appConfigPrefix := fmt.Sprintf("/apppack/apps/%s/config/", appName)
+	mockedAWS.On("GetParametersByPath", appConfigPrefix).Return(map[string]string{}, nil)
+	mockedState := emptyState()
+	mockedState.On("ReadEnvFile").Return(&map[string]string{}, nil)
+
+	t.Setenv("CODEBUILD_SOURCE_VERSION", "refs/heads/feature-branch")
+
+	b := Build{
+		Appname:          appName,
+		CodebuildBuildId: CodebuildBuildId,
+		aws:              mockedAWS,
+		state:            mockedState,
+		Ctx:              testContext,
+	}
+	env, err := b.LoadBuildEnv()
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+	if env["CI_COMMIT_REF"] != "refs/heads/feature-branch" {
+		t.Errorf("expected CI_COMMIT_REF=refs/heads/feature-branch, got %s", env["CI_COMMIT_REF"])
+	}
+}
+
 func TestGenerateDockerEnvStrings(t *testing.T) {
 	env := map[string]string{
 		"FOO": "bar",

--- a/builder/build/build_test.go
+++ b/builder/build/build_test.go
@@ -127,6 +127,7 @@ func TestLoadBuildEnvCIVarsFallback(t *testing.T) {
 	mockedState := emptyState()
 	mockedState.On("ReadEnvFile").Return(&map[string]string{}, nil)
 
+	t.Setenv("CODEBUILD_WEBHOOK_HEAD_REF", "")
 	t.Setenv("CODEBUILD_SOURCE_VERSION", "refs/heads/feature-branch")
 
 	b := Build{


### PR DESCRIPTION
## Summary
- Maps CodeBuild-specific environment variables to neutral, industry-standard CI names and injects them into Docker/buildpack build environments as build args
- `CODEBUILD_WEBHOOK_HEAD_REF` (falls back to `CODEBUILD_SOURCE_VERSION` for manual builds) → `CI_COMMIT_REF`
- `CODEBUILD_RESOLVED_SOURCE_VERSION` → `CI_COMMIT_SHA`
- `CODEBUILD_START_TIME` → `CI_BUILD_STARTED_AT`
- `CODEBUILD_SOURCE_REPO_URL` → `CI_REPOSITORY_URL`

## Test Plan
- [x] Added `TestLoadBuildEnvCIVars` — verifies all four CI vars are populated from CodeBuild env vars
- [x] Added `TestLoadBuildEnvCIVarsFallback` — verifies `CI_COMMIT_REF` falls back to `CODEBUILD_SOURCE_VERSION` when `CODEBUILD_WEBHOOK_HEAD_REF` is not set (manual builds)
- [x] All existing tests continue to pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)