### PR TITLE
Give in-dyno addon containers unique names

### DIFF
--- a/builder/build/postbuild.go
+++ b/builder/build/postbuild.go
@@ -86,7 +86,7 @@ func (b *Build) RunPostbuild() error {
 	if b.System() == BuildpackBuildSystemKeyword {
 		entrypoint = []string{"/cnb/lifecycle/launcher"}
 	}
-	err = b.containers.RunContainer(containerID, b.CodebuildBuildId, &container.Config{
+	err = b.containers.RunContainer(containerID, b.CodebuildBuildId, nil, &container.Config{
 		Image:      imageName,
 		Cmd:        []string{"/bin/sh", "-c", testScript},
 		Entrypoint: entrypoint,

--- a/builder/build/prebuild.go
+++ b/builder/build/prebuild.go
@@ -348,6 +348,11 @@ func (b *Build) StartAddons() (map[string]string, error) {
 	addons := removeDuplicateStr(b.AppJSON.GetTestAddons())
 	redisImage := "redis:alpine"
 	postgresImage := "postgres:alpine"
+	// Container names must be unique on the CodeBuild Docker daemon (which is
+	// reused across builds), so prefix them with the build ID. The friendly
+	// name ("redis"/"db") is kept as a network alias so other containers can
+	// still reach the addon by that hostname.
+	namePrefix := strings.ReplaceAll(b.CodebuildBuildId, ":", "-")
 	// use a switch statement to iterate over addons
 	for _, addon := range addons {
 		switch addon {
@@ -355,7 +360,7 @@ func (b *Build) StartAddons() (map[string]string, error) {
 			if err = b.containers.PullImage(redisImage); err != nil {
 				return nil, err
 			}
-			if err = b.containers.RunContainer("redis", b.CodebuildBuildId, &container.Config{Image: redisImage}); err != nil {
+			if err = b.containers.RunContainer(fmt.Sprintf("%s-redis", namePrefix), b.CodebuildBuildId, []string{"redis"}, &container.Config{Image: redisImage}); err != nil {
 				return nil, err
 			}
 			envOverides["REDIS_URL"] = "redis://redis:6379"
@@ -363,7 +368,7 @@ func (b *Build) StartAddons() (map[string]string, error) {
 			if err = b.containers.PullImage(postgresImage); err != nil {
 				return nil, err
 			}
-			if err = b.containers.RunContainer("db", b.CodebuildBuildId, &container.Config{Image: postgresImage}); err != nil {
+			if err = b.containers.RunContainer(fmt.Sprintf("%s-db", namePrefix), b.CodebuildBuildId, []string{"db"}, &container.Config{Image: postgresImage}); err != nil {
 				return nil, err
 			}
 			envOverides["DATABASE_URL"] = "postgres://postgres:postgres@db:5432/postgres"

--- a/builder/build/prebuild_test.go
+++ b/builder/build/prebuild_test.go
@@ -165,8 +165,8 @@ func (c *MockContainers) CreateContainer(s1 string, cfg *container.Config) (*str
 	return args.Get(0).(*string), args.Error(1)
 }
 
-func (c *MockContainers) RunContainer(s1 string, s2 string, cfg *container.Config) error {
-	args := c.Called(s1, s2, cfg)
+func (c *MockContainers) RunContainer(s1 string, s2 string, aliases []string, cfg *container.Config) error {
+	args := c.Called(s1, s2, aliases, cfg)
 	return args.Error(0)
 }
 
@@ -578,7 +578,7 @@ func TestStartAddons(t *testing.T) {
 	).Return(nil)
 	mockedContainers.On(
 		"RunContainer",
-		"redis", CodebuildBuildId, &container.Config{Image: "redis:alpine"},
+		fmt.Sprintf("%s-redis", CodebuildBuildId), CodebuildBuildId, []string{"redis"}, &container.Config{Image: "redis:alpine"},
 	).Return(nil)
 	mockedContainers.On(
 		"PullImage",
@@ -586,7 +586,7 @@ func TestStartAddons(t *testing.T) {
 	).Return(nil)
 	mockedContainers.On(
 		"RunContainer",
-		"db", CodebuildBuildId, &container.Config{Image: "postgres:alpine"},
+		fmt.Sprintf("%s-db", CodebuildBuildId), CodebuildBuildId, []string{"db"}, &container.Config{Image: "postgres:alpine"},
 	).Return(nil)
 	b := Build{
 		CodebuildBuildId: CodebuildBuildId,

--- a/builder/containers/containers.go
+++ b/builder/containers/containers.go
@@ -48,7 +48,7 @@ type ContainersI interface {
 	BuildImage(string, *BuildConfig) error
 	CreateContainer(string, *container.Config) (*string, error)
 	DeleteContainer(string) error
-	RunContainer(string, string, *container.Config) error
+	RunContainer(string, string, []string, *container.Config) error
 	GetContainerFile(string, string) (io.ReadCloser, error)
 	WaitForExit(string) (int, error)
 	AttachLogs(string, io.Writer, io.Writer) error
@@ -141,13 +141,21 @@ func (c *Containers) CreateContainer(name string, config *container.Config) (*st
 	return &resp.ID, nil
 }
 
-func (c *Containers) RunContainer(name string, networkID string, config *container.Config) error {
-	c.Log().Debug().Str("image", config.Image).Str("container", name).Msg("starting container")
+// RunContainer creates and starts a container connected to networkID. The
+// container is created with the (unique) name so it never collides on a
+// reused Docker daemon. Any aliases are registered as network-scoped
+// hostnames so other containers can reach it by a friendly name (e.g. "db").
+func (c *Containers) RunContainer(name string, networkID string, aliases []string, config *container.Config) error {
+	c.Log().Debug().Str("image", config.Image).Str("container", name).Strs("aliases", aliases).Msg("starting container")
 	containerID, err := c.CreateContainer(name, config)
 	if err != nil {
 		return err
 	}
-	err = c.cli.NetworkConnect(c.ctx, networkID, *containerID, nil)
+	var endpoint *network.EndpointSettings
+	if len(aliases) > 0 {
+		endpoint = &network.EndpointSettings{Aliases: aliases}
+	}
+	err = c.cli.NetworkConnect(c.ctx, networkID, *containerID, endpoint)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

A client build failed in the prebuild phase with:

```
FTL Error error="Error response from daemon: Conflict. The container name \"/db\" is already in use by container \"6b84fe4b...\". You have to remove (or rename) that container to be able to reuse that name."
```

CodeBuild reuses the Docker daemon across builds. The in-dyno test addons (`db`, `redis`) were created with fixed container names, so a leftover container from a previous build collides on the next one.

## Fix

Prefix the addon container names with the (unique) CodeBuild build ID — the same scheme already used for the buildx builder and the test container. The friendly `db`/`redis` names are preserved as **network aliases**, so other containers can still reach the addon by hostname (e.g. `DATABASE_URL=postgres://...@db:5432/postgres`).

`RunContainer` gains an `aliases []string` parameter; the postbuild test container passes `nil` (it's already uniquely named).

## Testing

Wrote a throwaway integration test against a real Docker daemon:

- **Reproduced the original bug** — a second container named `db` on the same daemon fails with `Conflict. The container name "/db" is already in use`.
- **Verified the fix** — two builds sharing one daemon each start their `db` addon with unique names (`<build-id>-db`) and no conflict; the `db` network alias still resolves (`getent hosts db` → `172.19.0.2  db`), so `DATABASE_URL=...@db:5432` is unaffected.
- `go test ./...` passes.

Closes #27
