### PR TITLE
Finalize CHANGELOG for 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Removed support for EOL `heroku-20` builds 
 
+### Fixed
+
+* Builds that use an in-dyno test database or Redis add-on (`heroku-postgresql:in-dyno`,
+  `heroku-redis:in-dyno`) could intermittently fail during the pre-build phase with an
+  error like `The container name "/db" is already in use`. These add-on containers now
+  start with unique names, so a build no longer collides with a leftover container from
+  a previous run.
+
 ## [2.5.0] - 2025-10-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-07-21
+
 ### Changed
 
 * Removed support for EOL `heroku-20` builds 


### PR DESCRIPTION
Adds the addon container naming fix (#27) to the changelog and cuts the 2.6.0 release section. These entries were lost when #28 merged only the code commit.